### PR TITLE
Add tensorflow to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ opencv-contrib-python
 tqdm
 tensorpack
 dill
+tensorflow>1.15


### PR DESCRIPTION
When testing this for the CS471 students, tensorflow was missing from the requirements and the basic getting started test would not run.